### PR TITLE
v1.0.2

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -7,7 +7,7 @@ on:
       - alpha
 
 jobs:
-  build-and-release:
+  publish-github:
     if: github.repository_owner == 'Lyttle-Development'
     runs-on: ubuntu-22.04
     env:
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build project
         run: |
-          ./gradlew shadowJar --stacktrace
+          ./gradlew build shadowJar --stacktrace
 
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v4
@@ -94,6 +94,10 @@ jobs:
           check-latest: true
         # Sets up Java 21 for building and publishing
 
+      - name: Build project
+        run: |
+          ./gradlew build shadowJar --stacktrace
+
       - name: Publish to Hangar
         env:
           HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
@@ -126,6 +130,10 @@ jobs:
           java-version: 21
           check-latest: true
         # Sets up Java 21 for building and publishing
+
+      - name: Build project
+        run: |
+          ./gradlew build shadowJar --stacktrace
 
       - name: Publish to Modrinth
         env:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -17,9 +17,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        # Checks out your code so the workflow can access it
 
-      - name: Validate Gradle wrapper
+      - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@v3
+        # Ensures the checked-in Gradle wrapper is valid and secure
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -27,17 +29,11 @@ jobs:
           distribution: 'corretto'
           java-version: 21
           check-latest: true
-
-      - name: Setup GitHub Packages credentials for Gradle
-        run: |
-          echo "githubPackagesUsername=${GPR_USER}" >> $GITHUB_ENV
-          echo "githubPackagesPassword=${GPR_API_KEY}" >> $GITHUB_ENV
+        # Sets up Java 21 for building and publishing
 
       - name: Build project
         run: |
-          ./gradlew shadowJar --stacktrace \
-            -Pgpr.user="${GPR_USER}" \
-            -Pgpr.key="${GPR_API_KEY}"
+          ./gradlew shadowJar --stacktrace
 
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v4
@@ -74,7 +70,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-hangar:
-    needs: build-and-release
     if: github.repository_owner == 'Lyttle-Development'
     runs-on: ubuntu-22.04
     env:
@@ -85,6 +80,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        # Checks out your code so the workflow can access it
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+        # Ensures the checked-in Gradle wrapper is valid and secure
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -92,31 +92,17 @@ jobs:
           distribution: 'corretto'
           java-version: 21
           check-latest: true
-
-      - name: Setup GitHub Packages credentials for Gradle
-        run: |
-          echo "githubPackagesUsername=${GPR_USER}" >> $GITHUB_ENV
-          echo "githubPackagesPassword=${GPR_API_KEY}" >> $GITHUB_ENV
-
-      - name: Download JAR artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: plugin-jar
-          path: ./dist
+        # Sets up Java 21 for building and publishing
 
       - name: Publish to Hangar
         env:
           HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
           CHANNEL: ${{ github.ref_name == 'main' && 'Release' || 'Alpha' }}
-          GPR_USER: ${{ secrets.GPR_USER }}
-          GPR_API_KEY: ${{ secrets.GPR_API_KEY }}
         run: |
-          ./gradlew publishPluginPublicationToHangar --stacktrace \
-            -Pgpr.user="${GPR_USER}" \
-            -Pgpr.key="${GPR_API_KEY}"
+          # Uploads the plugin to Hangar platform
+          ./gradlew publishPluginPublicationToHangar --stacktrace
 
   publish-modrinth:
-    needs: build-and-release
     if: github.repository_owner == 'Lyttle-Development'
     runs-on: ubuntu-22.04
     env:
@@ -127,6 +113,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        # Checks out your code so the workflow can access it
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+        # Ensures the checked-in Gradle wrapper is valid and secure
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -134,25 +125,12 @@ jobs:
           distribution: 'corretto'
           java-version: 21
           check-latest: true
-
-      - name: Setup GitHub Packages credentials for Gradle
-        run: |
-          echo "githubPackagesUsername=${GPR_USER}" >> $GITHUB_ENV
-          echo "githubPackagesPassword=${GPR_API_KEY}" >> $GITHUB_ENV
-
-      - name: Download JAR artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: plugin-jar
-          path: ./dist
+        # Sets up Java 21 for building and publishing
 
       - name: Publish to Modrinth
         env:
           MODRINTH_API_TOKEN: ${{ secrets.MODRINTH_API_TOKEN }}
           CHANNEL: ${{ github.ref_name == 'main' && 'Release' || 'Alpha' }}
-          GPR_USER: ${{ secrets.GPR_USER }}
-          GPR_API_KEY: ${{ secrets.GPR_API_KEY }}
         run: |
-          ./gradlew modrinth --stacktrace \
-            -Pgpr.user="${GPR_USER}" \
-            -Pgpr.key="${GPR_API_KEY}"
+          # Publishes to Modrinth (ensure your build.gradle is configured for this)
+          ./gradlew modrinth --stacktrace


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow in `.github/workflows/release-and-publish.yml` to simplify the build and publish process. It removes unnecessary credential handling, consolidates build steps, and adds helpful comments for clarity. The workflow now directly builds and publishes in each job, making the process more straightforward and maintainable.

**Workflow refactoring and simplification:**

* Merged the build and release steps into each publish job (`publish-github`, `publish-hangar`, `publish-modrinth`), removing the separate `build-and-release` job and the need for artifact downloading between jobs. [[1]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dL10-R10) [[2]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dL77)
* Removed explicit setup and use of GitHub Packages credentials (`GPR_USER`, `GPR_API_KEY`) from the build and publish steps, simplifying the environment and command usage. [[1]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR20-R36) [[2]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR83-L119) [[3]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR120-R144)
* Consolidated the build process in each job to use `./gradlew build shadowJar --stacktrace` before publishing, ensuring a fresh build for each publish target. [[1]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR20-R36) [[2]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR83-L119) [[3]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR120-R144)

**Documentation and clarity improvements:**

* Added descriptive comments to each workflow step to explain their purpose and improve maintainability for future contributors. [[1]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR20-R36) [[2]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR83-L119) [[3]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR120-R144)

**Consistency improvements:**

* Standardized step names (e.g., "Validate Gradle Wrapper") and ensured all jobs use the same sequence of setup steps for consistency across publishing targets. [[1]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR20-R36) [[2]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR83-L119) [[3]](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR120-R144)